### PR TITLE
feat: build planning poker experience

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,590 @@
-#root {
+.app-shell {
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(79, 70, 229, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.18), transparent 50%),
+    #f5f7fb;
+  padding: 3rem 1.5rem 4rem;
+  color: #0f172a;
+}
+
+.landing {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+}
+
+.landing-panel {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 28px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.landing-panel.identity h1 {
+  margin: 0;
+  font-size: 2.4rem;
+  font-weight: 700;
+}
+
+.landing-panel.identity p {
+  margin: 0.5rem 0 2rem;
+  color: #475569;
+}
+
+.identity-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.avatar-preview {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #fff;
+  align-self: flex-start;
+}
+
+.identity-form label {
+  font-weight: 600;
+}
+
+.identity-form input,
+.identity-form textarea,
+.identity-form select {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  padding: 0.9rem 1rem;
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.identity-form input:focus,
+.identity-form textarea:focus,
+.identity-form select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
+}
+
+.color-picker {
+  margin: 0.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.color-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  gap: 0.6rem;
+}
+
+.color-swatch {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.color-swatch:hover {
+  transform: translateY(-2px);
+}
+
+.color-swatch.selected {
+  border-color: rgba(15, 23, 42, 0.4);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.15);
+}
+
+.identity-form button,
+.action-form button {
+  border-radius: 16px;
+  padding: 0.85rem 1.4rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.identity-form button.primary,
+.action-form button.primary {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+  box-shadow: 0 14px 28px rgba(99, 102, 241, 0.3);
+}
+
+.identity-form button.primary:hover,
+.action-form button.primary:hover {
+  transform: translateY(-1px);
+}
+
+.action-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 16px 48px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.action-card h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.action-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.deck-options {
+  border: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.deck-options legend {
+  font-weight: 600;
+}
+
+.radio-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.radio-grid label {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 500;
+  color: #334155;
+}
+
+.custom-deck textarea {
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  min-height: 120px;
+}
+
+.preview-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.preview-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.preview-cards span {
+  background: rgba(99, 102, 241, 0.1);
+  color: #4338ca;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.action-form button.secondary {
+  background: #fff;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  color: #4338ca;
+}
+
+.action-form button.secondary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(99, 102, 241, 0.18);
+}
+
+.form-error {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #dc2626;
+}
+
+.room-screen {
   max-width: 1280px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.room-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 1.75rem 2.5rem;
+  border-radius: 24px;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.1);
+}
+
+.room-info h1 {
+  margin: 0 0 0.4rem;
+  font-size: 1.9rem;
+}
+
+.room-info p {
+  margin: 0;
+  color: #475569;
+}
+
+.room-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.room-actions button {
+  border-radius: 999px;
+  padding: 0.75rem 1.4rem;
+  font-weight: 600;
+}
+
+.room-actions .secondary {
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+}
+
+.room-actions .ghost {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+  border: none;
+}
+
+.room-content {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 2rem;
+}
+
+.participants-panel {
+  background: rgba(255, 255, 255, 0.92);
   padding: 2rem;
+  border-radius: 24px;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.participants-panel h2 {
+  margin: 0;
+}
+
+.participants-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.participants-panel li {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.participants-panel li.me {
+  border: 2px solid rgba(99, 102, 241, 0.4);
+  background: rgba(99, 102, 241, 0.1);
+}
+
+.participants-panel .avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+}
+
+.vote-status {
+  display: block;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.icon-button {
+  margin-left: auto;
+  border: none;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.icon-button:hover {
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.host-tools {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.host-tools button {
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+}
+
+.transfer-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.transfer-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.transfer-row select {
+  flex: 1;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.6rem 0.75rem;
+}
+
+.transfer-row button {
+  border-radius: 14px;
+  padding: 0.6rem 1rem;
+  background: #2563eb;
+  color: #fff;
+  border: none;
+}
+
+.vote-summary ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.vote-summary li {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+  background: rgba(226, 232, 240, 0.7);
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+}
+
+.table-area {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.table-wrapper {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+.poker-table {
+  width: min(640px, 100%);
+  aspect-ratio: 3 / 2;
+  border-radius: 50% / 45%;
+  background: radial-gradient(circle at 30% 20%, rgba(59, 130, 246, 0.2), transparent 50%),
+    linear-gradient(135deg, #4f46e5, #2563eb);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #e0f2fe;
+  padding: 1rem;
+}
+
+.poker-table.revealed {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+}
+
+.table-status {
+  background: rgba(15, 23, 42, 0.35);
+  padding: 1rem 1.5rem;
+  border-radius: 18px;
+  font-weight: 600;
   text-align: center;
+  max-width: 70%;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.seats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.seat {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  color: #fff;
+}
+
+.seat .seat-avatar {
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #fff;
+  border: 3px solid rgba(15, 23, 42, 0.25);
+}
+
+.seat .seat-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-shadow: 0 2px 8px rgba(15, 23, 42, 0.4);
+}
+
+.seat .seat-card {
+  background: rgba(15, 23, 42, 0.35);
+  padding: 0.45rem 0.75rem;
+  border-radius: 12px;
+  min-width: 32px;
+  text-align: center;
+  font-weight: 700;
+}
+
+.seat.hidden .seat-card {
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.seat.empty .seat-card {
+  background: rgba(15, 23, 42, 0.25);
+}
+
+.deck {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.card-row .card {
+  min-width: 60px;
+  min-height: 86px;
+  border-radius: 18px;
+  border: none;
+  background: linear-gradient(160deg, #fff, #e2e8f0);
+  color: #0f172a;
+  font-size: 1.2rem;
+  font-weight: 700;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.card-row .card:hover:not(:disabled) {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.15);
+}
+
+.card-row .card.selected {
+  outline: 3px solid rgba(99, 102, 241, 0.6);
+  transform: translateY(-6px);
+}
+
+.card-row .card:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.deck .ghost {
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: transparent;
+  font-weight: 600;
+}
+
+@media (max-width: 980px) {
+  .landing {
+    grid-template-columns: 1fr;
   }
-  to {
-    transform: rotate(360deg);
+
+  .room-content {
+    grid-template-columns: 1fr;
+  }
+
+  .participants-panel {
+    order: 2;
+  }
+
+  .table-area {
+    order: 1;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 2rem 1rem 3rem;
   }
-}
 
-.card {
-  padding: 2em;
-}
+  .landing-panel,
+  .room-header,
+  .participants-panel,
+  .table-area {
+    padding: 1.5rem;
+    border-radius: 20px;
+  }
 
-.read-the-docs {
-  color: #888;
+  .room-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .card-row {
+    justify-content: center;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,198 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useState } from 'react'
 import './App.css'
+import {
+  createRoom,
+  joinRoom,
+  leaveRoom,
+  updateParticipantProfile,
+  useRoom,
+} from './roomStore'
+import type { DeckType } from './roomStore'
+import type { SessionProfile } from './types'
+import LandingView from './components/LandingView'
+import RoomView from './components/RoomView'
+
+const SESSION_STORAGE_KEY = 'planning-poker-session'
+const CURRENT_ROOM_KEY = 'planning-poker-current-room'
+const DEFAULT_COLOR = '#3498db'
+
+function loadStoredSession(): SessionProfile | null {
+  if (typeof window === 'undefined') return null
+  const stored = window.localStorage.getItem(SESSION_STORAGE_KEY)
+  if (!stored) return null
+  try {
+    const parsed = JSON.parse(stored) as SessionProfile
+    if (!parsed.id) return null
+    return parsed
+  } catch (error) {
+    console.warn('Não foi possível restaurar a sessão', error)
+    return null
+  }
+}
+
+function loadStoredRoom(): string | null {
+  if (typeof window === 'undefined') return null
+  return window.localStorage.getItem(CURRENT_ROOM_KEY)
+}
+
+function generateSessionId() {
+  return 'USR-' + Math.random().toString(36).slice(2, 8).toUpperCase()
+}
+
+function parseCustomDeck(input: string) {
+  return input
+    .split(/\s*[,\n]\s*/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
+
+function ensureSession(base: SessionProfile | null): SessionProfile {
+  if (base) return base
+  const now = Date.now()
+  return {
+    id: generateSessionId(),
+    name: '',
+    avatarColor: DEFAULT_COLOR,
+    joinedAt: now,
+  }
+}
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [session, setSession] = useState<SessionProfile | null>(() => ensureSession(loadStoredSession()))
+  const [currentRoomId, setCurrentRoomId] = useState<string | null>(() => loadStoredRoom())
+  const [errors, setErrors] = useState({ session: null as string | null, create: null as string | null, join: null as string | null })
 
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  const room = useRoom(currentRoomId)
+  const isInRoom = Boolean(room)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (!session) return
+    window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session))
+  }, [session])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (currentRoomId) {
+      window.localStorage.setItem(CURRENT_ROOM_KEY, currentRoomId)
+    } else {
+      window.localStorage.removeItem(CURRENT_ROOM_KEY)
+    }
+  }, [currentRoomId])
+
+  useEffect(() => {
+    if (!room || !session) return
+    if (!room.participants[session.id]) {
+      setCurrentRoomId(null)
+    }
+  }, [room, session])
+
+  useEffect(() => {
+    if (!room || !session) return
+    const participant = room.participants[session.id]
+    if (!participant) return
+    if (participant.name === session.name && participant.avatarColor === session.avatarColor) return
+    updateParticipantProfile(room.id, session.id, {
+      name: session.name,
+      avatarColor: session.avatarColor,
+    })
+  }, [room, session])
+
+  function clearErrors() {
+    setErrors({ session: null, create: null, join: null })
+  }
+
+  function handleSessionUpdate(updates: Partial<SessionProfile>) {
+    setSession((previous) => {
+      const base = ensureSession(previous)
+      const merged: SessionProfile = {
+        ...base,
+        ...updates,
+        joinedAt: base.joinedAt,
+      }
+      if ('name' in updates) {
+        if (!merged.name.trim()) {
+          setErrors((current) => ({ ...current, session: 'Informe um nome para continuar.' }))
+        } else {
+          setErrors((current) => ({ ...current, session: null }))
+        }
+      }
+      return merged
+    })
+  }
+
+  function handleCreateRoom(values: { roomName: string; deckType: DeckType; customDeck: string }) {
+    if (!session) return
+    const trimmedName = session.name.trim()
+    if (!trimmedName) {
+      setErrors((current) => ({ ...current, session: 'Informe um nome antes de criar uma sala.' }))
+      return
+    }
+
+    const deckValues = values.deckType === 'custom' ? parseCustomDeck(values.customDeck) : undefined
+    const hostProfile: SessionProfile = {
+      ...session,
+      name: trimmedName,
+      joinedAt: Date.now(),
+    }
+
+    const roomId = createRoom({
+      name: values.roomName.trim() || `${trimmedName} - Planning Poker`,
+      deckType: values.deckType,
+      customDeck: deckValues,
+      host: hostProfile,
+    })
+
+    setCurrentRoomId(roomId)
+    clearErrors()
+  }
+
+  function handleJoinRoom(roomIdRaw: string) {
+    if (!session) return
+    const trimmedName = session.name.trim()
+    if (!trimmedName) {
+      setErrors((current) => ({ ...current, session: 'Informe um nome antes de entrar em uma sala.' }))
+      return
+    }
+
+    const roomId = roomIdRaw.trim().toUpperCase()
+    const result = joinRoom(roomId, {
+      ...session,
+      name: trimmedName,
+      joinedAt: Date.now(),
+    })
+
+    if (!result.success) {
+      setErrors((current) => ({ ...current, join: result.reason ?? 'Não foi possível entrar na sala.' }))
+      return
+    }
+
+    setCurrentRoomId(roomId)
+    clearErrors()
+  }
+
+  function handleLeaveRoom() {
+    if (!room || !session) return
+    leaveRoom(room.id, session.id)
+    setCurrentRoomId(null)
+  }
+
+  const content = isInRoom && room && session && session.name.trim()
+    ? (
+        <RoomView room={room} session={session} onLeave={handleLeaveRoom} />
+      )
+    : (
+        <LandingView
+          session={session}
+          onSessionUpdate={handleSessionUpdate}
+          onCreateRoom={handleCreateRoom}
+          onJoinRoom={handleJoinRoom}
+          errors={errors}
+          clearError={clearErrors}
+        />
+      )
+
+  return <div className="app-shell">{content}</div>
 }
 
 export default App

--- a/src/components/LandingView.tsx
+++ b/src/components/LandingView.tsx
@@ -1,0 +1,225 @@
+import { useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+import type { DeckType } from '../roomStore'
+import type { CreateRoomFormValues, SessionProfile } from '../types'
+
+const AVATAR_COLORS = ['#1abc9c', '#3498db', '#9b59b6', '#e67e22', '#e74c3c', '#f1c40f', '#2ecc71', '#ff6b6b']
+
+interface LandingViewProps {
+  session: SessionProfile | null
+  onSessionUpdate: (updates: Partial<SessionProfile>) => void
+  onCreateRoom: (values: CreateRoomFormValues) => void
+  onJoinRoom: (roomId: string) => void
+  errors: {
+    session?: string | null
+    create?: string | null
+    join?: string | null
+  }
+  clearError: () => void
+}
+
+export function LandingView({
+  session,
+  onSessionUpdate,
+  onCreateRoom,
+  onJoinRoom,
+  errors,
+  clearError,
+}: LandingViewProps) {
+  const [nameInput, setNameInput] = useState(session?.name ?? '')
+  const [roomName, setRoomName] = useState('')
+  const [deckType, setDeckType] = useState<DeckType>('fibonacci')
+  const [customDeck, setCustomDeck] = useState('1, 2, 3, 5, 8, 13')
+  const [roomIdInput, setRoomIdInput] = useState('')
+
+  const avatarColor = session?.avatarColor ?? AVATAR_COLORS[0]
+
+  const customDeckPreview = useMemo(() => {
+    return customDeck
+      .split(/\s*[,\n]\s*/)
+      .map((value) => value.trim())
+      .filter(Boolean)
+  }, [customDeck])
+
+  const hasIdentity = Boolean(session?.name)
+
+  function handleIdentitySubmit(event: FormEvent) {
+    event.preventDefault()
+    const trimmed = nameInput.trim()
+    if (!trimmed) {
+      return
+    }
+    onSessionUpdate({ name: trimmed })
+    clearError()
+  }
+
+  function handleColorChange(color: string) {
+    onSessionUpdate({ avatarColor: color })
+    clearError()
+  }
+
+  function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    clearError()
+    if (!hasIdentity) {
+      onSessionUpdate({ name: nameInput.trim() })
+      return
+    }
+    onCreateRoom({ roomName, deckType, customDeck })
+  }
+
+  function handleJoin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    clearError()
+    const cleanId = roomIdInput.trim()
+    if (!cleanId) return
+    onJoinRoom(cleanId)
+  }
+
+  return (
+    <div className="landing">
+      <section className="landing-panel identity">
+        <header>
+          <h1>Planning Poker</h1>
+          <p>Organize estimativas em tempo real com sua equipe.</p>
+        </header>
+
+        <form className="identity-form" onSubmit={handleIdentitySubmit}>
+          <span className="avatar-preview" style={{ backgroundColor: avatarColor }}>
+            {nameInput ? nameInput.charAt(0).toUpperCase() : '?'}
+          </span>
+          <label htmlFor="displayName">Seu nome</label>
+          <input
+            id="displayName"
+            type="text"
+            value={nameInput}
+            placeholder="Digite como deseja ser visto"
+            onChange={(event) => setNameInput(event.target.value)}
+            onFocus={clearError}
+          />
+          <div className="color-picker">
+            <span>Escolha uma cor:</span>
+            <div className="color-grid">
+              {AVATAR_COLORS.map((color) => (
+                <button
+                  key={color}
+                  type="button"
+                  className={`color-swatch${color === avatarColor ? ' selected' : ''}`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => handleColorChange(color)}
+                  aria-label={`Selecionar cor ${color}`}
+                />
+              ))}
+            </div>
+          </div>
+          <button type="submit" className="primary">
+            {hasIdentity ? 'Atualizar perfil' : 'Salvar perfil'}
+          </button>
+          {errors.session ? <p className="form-error">{errors.session}</p> : null}
+        </form>
+      </section>
+
+      <section className="landing-panel action">
+        <div className="action-card">
+          <h2>Criar uma nova sala</h2>
+          <form onSubmit={handleCreate} className="action-form">
+            <label htmlFor="roomName">Nome da sala</label>
+            <input
+              id="roomName"
+              type="text"
+              value={roomName}
+              onChange={(event) => setRoomName(event.target.value)}
+              placeholder="Time de produto, sprint, etc."
+              onFocus={clearError}
+            />
+
+            <fieldset className="deck-options">
+              <legend>Estilo de pontuação</legend>
+              <div className="radio-grid">
+                <label>
+                  <input
+                    type="radio"
+                    name="deckType"
+                    value="fibonacci"
+                    checked={deckType === 'fibonacci'}
+                    onChange={() => setDeckType('fibonacci')}
+                  />
+                  Fibonacci
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="deckType"
+                    value="numeric"
+                    checked={deckType === 'numeric'}
+                    onChange={() => setDeckType('numeric')}
+                  />
+                  Numérico (0 - 10)
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="deckType"
+                    value="custom"
+                    checked={deckType === 'custom'}
+                    onChange={() => setDeckType('custom')}
+                  />
+                  Customizado
+                </label>
+              </div>
+            </fieldset>
+
+            {deckType === 'custom' ? (
+              <div className="custom-deck">
+                <label htmlFor="customDeck">Valores das cartas</label>
+                <textarea
+                  id="customDeck"
+                  value={customDeck}
+                  onChange={(event) => setCustomDeck(event.target.value)}
+                  placeholder="Separe por vírgulas ou linhas. Ex: XS, S, M, L, XL"
+                  rows={3}
+                />
+                <div className="preview-row">
+                  <span>Pré-visualização:</span>
+                  <div className="preview-cards">
+                    {customDeckPreview.length > 0
+                      ? customDeckPreview.map((value) => (
+                          <span key={value}>{value}</span>
+                        ))
+                      : 'Nenhum valor informado'}
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            <button type="submit" className="primary" disabled={!hasIdentity}>
+              Criar sala
+            </button>
+            {errors.create ? <p className="form-error">{errors.create}</p> : null}
+          </form>
+        </div>
+
+        <div className="action-card join-card">
+          <h2>Entrar em uma sala existente</h2>
+          <form onSubmit={handleJoin} className="action-form">
+            <label htmlFor="roomId">ID da sala</label>
+            <input
+              id="roomId"
+              type="text"
+              value={roomIdInput}
+              onChange={(event) => setRoomIdInput(event.target.value.toUpperCase())}
+              placeholder="Ex: AB12-CD34"
+              onFocus={clearError}
+            />
+            <button type="submit" className="secondary" disabled={!hasIdentity}>
+              Entrar
+            </button>
+            {errors.join ? <p className="form-error">{errors.join}</p> : null}
+          </form>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default LandingView

--- a/src/components/RoomView.tsx
+++ b/src/components/RoomView.tsx
@@ -1,0 +1,255 @@
+import { useMemo, useState } from 'react'
+import { revealVotes, resetVotes, submitVote, removeParticipant, transferHost } from '../roomStore'
+import type { RoomState } from '../roomStore'
+import type { SessionProfile } from '../types'
+
+interface RoomViewProps {
+  room: RoomState
+  session: SessionProfile
+  onLeave: () => void
+}
+
+export function RoomView({ room, session, onLeave }: RoomViewProps) {
+  const [selectedTransferTarget, setSelectedTransferTarget] = useState('')
+  const [copyState, setCopyState] = useState<'idle' | 'copied'>('idle')
+
+  const participants = useMemo(() => {
+    return Object.values(room.participants).sort((a, b) => a.joinedAt - b.joinedAt)
+  }, [room.participants])
+
+  const votes = room.votes
+  const myVote = votes[session.id] ?? null
+  const isHost = room.hostId === session.id
+
+  const waitingParticipants = participants.filter((participant) => !votes[participant.id])
+  const everyoneVoted = waitingParticipants.length === 0
+
+  const voteSummary = useMemo(() => {
+    const counts = new Map<string, number>()
+    Object.values(votes).forEach((vote) => {
+      if (!vote) return
+      counts.set(vote, (counts.get(vote) ?? 0) + 1)
+    })
+    return Array.from(counts.entries()).sort((a, b) => b[1] - a[1])
+  }, [votes])
+
+  const statusMessage = (() => {
+    if (room.revealed) {
+      return 'Resultados revelados'
+    }
+    if (everyoneVoted) {
+      return 'Todos os votos recebidos. Revele quando quiser!'
+    }
+    if (waitingParticipants.length === 1) {
+      return `Aguardando ${waitingParticipants[0].name}...`
+    }
+    if (waitingParticipants.length > 1) {
+      return `Aguardando ${waitingParticipants.length} pessoas...`
+    }
+    return 'Escolha sua carta para votar'
+  })()
+
+  const deckValues = room.deckValues
+
+  function handleVote(value: string) {
+    if (room.revealed) return
+    submitVote(room.id, session.id, value)
+  }
+
+  async function handleCopyInvite() {
+    try {
+      await navigator.clipboard.writeText(room.id)
+      setCopyState('copied')
+      setTimeout(() => setCopyState('idle'), 2500)
+    } catch (error) {
+      console.warn('Falha ao copiar ID da sala', error)
+    }
+  }
+
+  function handleTransferSubmit() {
+    if (!selectedTransferTarget) return
+    transferHost(room.id, selectedTransferTarget)
+    setSelectedTransferTarget('')
+  }
+
+  const layoutSeats = participants.map((participant, index) => {
+    const angle = (index / participants.length) * 2 * Math.PI - Math.PI / 2
+    const radius = 38
+    const x = 50 + radius * Math.cos(angle)
+    const y = 50 + radius * Math.sin(angle)
+    const vote = votes[participant.id]
+    const displayVote = room.revealed ? vote ?? '—' : vote ? '•' : ''
+    const voteClass = room.revealed ? 'revealed' : vote ? 'hidden' : 'empty'
+
+    return {
+      participant,
+      style: {
+        left: `${x}%`,
+        top: `${y}%`,
+      } as const,
+      displayVote,
+      voteClass,
+    }
+  })
+
+  return (
+    <div className="room-screen">
+      <header className="room-header">
+        <div className="room-info">
+          <h1>{room.name}</h1>
+          <p>ID da sala: <strong>{room.id}</strong></p>
+        </div>
+        <div className="room-actions">
+          <button type="button" className="secondary" onClick={handleCopyInvite}>
+            {copyState === 'copied' ? 'ID copiado!' : 'Copiar ID' }
+          </button>
+          <button type="button" className="ghost" onClick={onLeave}>
+            Sair da sala
+          </button>
+        </div>
+      </header>
+
+      <div className="room-content">
+        <aside className="participants-panel">
+          <h2>Jogadores</h2>
+          <ul>
+            {participants.map((participant) => (
+              <li key={participant.id} className={participant.id === session.id ? 'me' : ''}>
+                <span className="avatar" style={{ backgroundColor: participant.avatarColor }}>
+                  {participant.name.charAt(0).toUpperCase()}
+                </span>
+                <div>
+                  <strong>
+                    {participant.name}
+                    {participant.id === session.id ? ' (você)' : ''}
+                    {participant.id === room.hostId ? ' ⭐' : ''}
+                  </strong>
+                  <span className="vote-status">
+                    {room.revealed
+                      ? votes[participant.id] ?? 'Sem voto'
+                      : votes[participant.id]
+                        ? 'Carta selecionada'
+                        : 'Aguardando voto'}
+                  </span>
+                </div>
+                {isHost && participant.id !== session.id ? (
+                  <button
+                    type="button"
+                    className="icon-button"
+                    onClick={() => removeParticipant(room.id, participant.id)}
+                  >
+                    ✕
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+
+          {isHost ? (
+            <div className="host-tools">
+              <h3>Ferramentas do anfitrião</h3>
+              <button
+                type="button"
+                className="primary"
+                onClick={() => revealVotes(room.id)}
+                disabled={room.revealed || participants.length === 0}
+              >
+                Revelar cartas
+              </button>
+              <button type="button" className="secondary" onClick={() => resetVotes(room.id)}>
+                Resetar rodada
+              </button>
+              <div className="transfer-control">
+                <label htmlFor="transferHost">Transferir controle</label>
+                <div className="transfer-row">
+                  <select
+                    id="transferHost"
+                    value={selectedTransferTarget}
+                    onChange={(event) => setSelectedTransferTarget(event.target.value)}
+                  >
+                    <option value="">Escolha um jogador</option>
+                    {participants
+                      .filter((participant) => participant.id !== room.hostId)
+                      .map((participant) => (
+                        <option value={participant.id} key={participant.id}>
+                          {participant.name}
+                        </option>
+                      ))}
+                  </select>
+                  <button type="button" onClick={handleTransferSubmit} disabled={!selectedTransferTarget}>
+                    Transferir
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {room.revealed && voteSummary.length > 0 ? (
+            <div className="vote-summary">
+              <h3>Distribuição</h3>
+              <ul>
+                {voteSummary.map(([value, count]) => (
+                  <li key={value}>
+                    <span>{value}</span>
+                    <span>{count} voto(s)</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </aside>
+
+        <main className="table-area">
+          <div className="table-wrapper">
+            <div className={`poker-table ${room.revealed ? 'revealed' : ''}`}>
+              <div className="table-status">{statusMessage}</div>
+              <ul className="seats">
+                {layoutSeats.map(({ participant, style, displayVote, voteClass }) => (
+                  <li key={participant.id} className={`seat ${voteClass}`} style={style}>
+                    <span className="seat-avatar" style={{ backgroundColor: participant.avatarColor }}>
+                      {participant.name.charAt(0).toUpperCase()}
+                    </span>
+                    <span className="seat-name">
+                      {participant.name}
+                      {participant.id === room.hostId ? ' ⭐' : ''}
+                    </span>
+                    <span className="seat-card" data-value={displayVote}>
+                      {displayVote}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+
+          <div className="deck">
+            <h3>Escolha sua carta</h3>
+            <div className="card-row">
+              {deckValues.map((value) => {
+                const isSelected = myVote === value
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    className={`card ${isSelected ? 'selected' : ''}`}
+                    onClick={() => handleVote(value)}
+                    disabled={room.revealed}
+                  >
+                    {value}
+                  </button>
+                )
+              })}
+              {myVote ? (
+                <button type="button" className="ghost" onClick={() => submitVote(room.id, session.id, null)}>
+                  Limpar voto
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  )
+}
+
+export default RoomView

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,45 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #0f172a;
+  background-color: #f1f5f9;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+*, *::before, *::after {
+  box-sizing: border-box;
 }
+
+a {
+  color: inherit;
+}
+
 a:hover {
-  color: #535bf2;
+  color: inherit;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background: #f1f5f9;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+button,
+input,
+textarea,
+select {
+  font: inherit;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+ul {
+  padding: 0;
+  margin: 0;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 }

--- a/src/roomStore.ts
+++ b/src/roomStore.ts
@@ -1,0 +1,292 @@
+import { useSyncExternalStore } from 'react'
+
+export type DeckType = 'fibonacci' | 'numeric' | 'custom'
+
+export interface ParticipantProfile {
+  id: string
+  name: string
+  avatarColor: string
+  joinedAt: number
+}
+
+export interface RoomState {
+  id: string
+  name: string
+  deckType: DeckType
+  deckValues: string[]
+  hostId: string
+  participants: Record<string, ParticipantProfile>
+  votes: Record<string, string | null>
+  revealed: boolean
+  createdAt: number
+}
+
+interface RoomsMap {
+  [roomId: string]: RoomState
+}
+
+const STORAGE_KEY = 'planning-poker-rooms'
+const BROADCAST_KEY = 'planning-poker-sync'
+
+const isBrowser = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+
+function loadRooms(): RoomsMap {
+  if (!isBrowser) return {}
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (!stored) return {}
+    const parsed = JSON.parse(stored) as RoomsMap
+    // Validate deck arrays to ensure they are arrays of strings
+    Object.values(parsed).forEach((room) => {
+      if (!Array.isArray(room.deckValues)) {
+        room.deckValues = []
+      } else {
+        room.deckValues = room.deckValues.map((value) => String(value))
+      }
+      room.revealed = Boolean(room.revealed)
+    })
+    return parsed
+  } catch (error) {
+    console.warn('Unable to parse rooms from storage', error)
+    return {}
+  }
+}
+
+let rooms: RoomsMap = loadRooms()
+const listeners = new Set<() => void>()
+
+const channel: BroadcastChannel | null = isBrowser && 'BroadcastChannel' in window
+  ? new BroadcastChannel(BROADCAST_KEY)
+  : null
+
+channel?.addEventListener('message', (event) => {
+  const data = event.data as { type?: string; payload?: unknown }
+  if (!data || typeof data !== 'object') return
+  if (data.type === 'rooms-sync' && data.payload && typeof data.payload === 'object') {
+    rooms = data.payload as RoomsMap
+    persist()
+    emit()
+  }
+})
+
+function emit() {
+  listeners.forEach((listener) => listener())
+}
+
+function persist() {
+  if (!isBrowser) return
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(rooms))
+}
+
+function broadcast() {
+  if (!channel) return
+  channel.postMessage({ type: 'rooms-sync', payload: rooms })
+}
+
+function updateRooms(mutator: (draft: RoomsMap) => void) {
+  const draft: RoomsMap = JSON.parse(JSON.stringify(rooms))
+  mutator(draft)
+  rooms = draft
+  persist()
+  broadcast()
+  emit()
+}
+
+export function getRoomsSnapshot(): RoomsMap {
+  return rooms
+}
+
+export function subscribeRooms(listener: () => void) {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function useRooms(): RoomsMap {
+  return useSyncExternalStore(subscribeRooms, getRoomsSnapshot, () => ({} as RoomsMap))
+}
+
+export function useRoom(roomId: string | null) {
+  const allRooms = useRooms()
+  if (!roomId) return null
+  return allRooms[roomId] ?? null
+}
+
+export interface CreateRoomOptions {
+  name: string
+  deckType: DeckType
+  customDeck?: string[]
+  host: ParticipantProfile
+}
+
+const PRESET_DECKS: Record<Exclude<DeckType, 'custom'>, string[]> = {
+  fibonacci: ['0', '1', '2', '3', '5', '8', '13', '21', '34', '55', '89', '?', '☕'],
+  numeric: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '?', '☕'],
+}
+
+function resolveDeck(deckType: DeckType, customDeck?: string[]) {
+  if (deckType === 'custom') {
+    const deck = (customDeck ?? []).map((value) => value.trim()).filter((value) => value.length > 0)
+    return deck.length > 0 ? deck : ['?']
+  }
+  return [...PRESET_DECKS[deckType]]
+}
+
+export function createRoom(options: CreateRoomOptions) {
+  const id = generateRoomId()
+  const deckValues = resolveDeck(options.deckType, options.customDeck)
+  const participant: ParticipantProfile = {
+    id: options.host.id,
+    name: options.host.name,
+    avatarColor: options.host.avatarColor,
+    joinedAt: options.host.joinedAt,
+  }
+
+  const votes: Record<string, string | null> = {
+    [participant.id]: null,
+  }
+
+  const room: RoomState = {
+    id,
+    name: options.name.trim() || 'Sala sem nome',
+    deckType: options.deckType,
+    deckValues,
+    hostId: participant.id,
+    participants: {
+      [participant.id]: participant,
+    },
+    votes,
+    revealed: false,
+    createdAt: Date.now(),
+  }
+
+  updateRooms((draft) => {
+    draft[id] = room
+  })
+
+  return id
+}
+
+export interface JoinRoomResult {
+  success: boolean
+  reason?: string
+  room?: RoomState
+}
+
+export function joinRoom(roomId: string, profile: ParticipantProfile): JoinRoomResult {
+  const currentRoom = rooms[roomId]
+  if (!currentRoom) {
+    return { success: false, reason: 'Sala não encontrada.' }
+  }
+
+  updateRooms((draft) => {
+    const room = draft[roomId]
+    if (!room) return
+
+    room.participants[profile.id] = {
+      id: profile.id,
+      name: profile.name,
+      avatarColor: profile.avatarColor,
+      joinedAt: room.participants[profile.id]?.joinedAt ?? profile.joinedAt,
+    }
+
+    if (!(profile.id in room.votes)) {
+      room.votes[profile.id] = null
+    }
+  })
+
+  return { success: true, room: rooms[roomId] }
+}
+
+export function leaveRoom(roomId: string, participantId: string) {
+  const currentRoom = rooms[roomId]
+  if (!currentRoom) return
+
+  updateRooms((draft) => {
+    const room = draft[roomId]
+    if (!room) return
+
+    delete room.participants[participantId]
+    delete room.votes[participantId]
+
+    const remainingIds = Object.keys(room.participants)
+    if (remainingIds.length === 0) {
+      delete draft[roomId]
+      return
+    }
+
+    if (room.hostId === participantId) {
+      room.hostId = remainingIds[0]
+    }
+
+    if (room.revealed && remainingIds.length === 0) {
+      room.revealed = false
+    }
+  })
+}
+
+export function updateParticipantProfile(
+  roomId: string,
+  participantId: string,
+  updates: Partial<Omit<ParticipantProfile, 'id' | 'joinedAt'>>,
+) {
+  updateRooms((draft) => {
+    const room = draft[roomId]
+    if (!room) return
+    const participant = room.participants[participantId]
+    if (!participant) return
+    room.participants[participantId] = {
+      ...participant,
+      ...updates,
+    }
+  })
+}
+
+export function submitVote(roomId: string, participantId: string, value: string | null) {
+  updateRooms((draft) => {
+    const room = draft[roomId]
+    if (!room) return
+    if (!(participantId in room.participants)) return
+    room.votes[participantId] = value
+    if (value === null) {
+      room.revealed = false
+    }
+  })
+}
+
+export function revealVotes(roomId: string) {
+  updateRooms((draft) => {
+    const room = draft[roomId]
+    if (!room) return
+    room.revealed = true
+  })
+}
+
+export function resetVotes(roomId: string) {
+  updateRooms((draft) => {
+    const room = draft[roomId]
+    if (!room) return
+    Object.keys(room.votes).forEach((participantId) => {
+      room.votes[participantId] = null
+    })
+    room.revealed = false
+  })
+}
+
+export function removeParticipant(roomId: string, participantId: string) {
+  leaveRoom(roomId, participantId)
+}
+
+export function transferHost(roomId: string, newHostId: string) {
+  updateRooms((draft) => {
+    const room = draft[roomId]
+    if (!room) return
+    if (!(newHostId in room.participants)) return
+    room.hostId = newHostId
+  })
+}
+
+function generateRoomId() {
+  return Math.random().toString(36).slice(2, 6).toUpperCase() + '-' + Date.now().toString(36).slice(-4).toUpperCase()
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+import type { DeckType } from './roomStore'
+
+export interface SessionProfile {
+  id: string
+  name: string
+  avatarColor: string
+  joinedAt: number
+}
+
+export interface CreateRoomFormValues {
+  roomName: string
+  deckType: DeckType
+  customDeck: string
+}


### PR DESCRIPTION
## Summary
- replace the starter view with a login flow that captures the player's identity and allows creating or joining planning poker rooms
- implement a shared room store with BroadcastChannel syncing so participants can vote, reveal, reset, transfer host controls, and be removed in real time
- style the lobby and table screens with a poker inspired layout including circular seating, deck cards, and responsive host controls

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5de917030832a9dce317dce65cc59